### PR TITLE
pc-bios/s390-ccw/net: fix a possible memory leak in get_uuid()

### DIFF
--- a/pc-bios/s390-ccw/netmain.c
+++ b/pc-bios/s390-ccw/netmain.c
@@ -268,6 +268,7 @@ static const char *get_uuid(void)
                  : "d" (r0), "d" (r1), [addr] "a" (buf)
                  : "cc", "memory");
     if (cc) {
+        free(mem);
         return NULL;
     }
 


### PR DESCRIPTION
There is a possible memory leak in get_uuid(). Should free allocated mem before return NULL.